### PR TITLE
fix #3 : input el is not defined when nested loading

### DIFF
--- a/src/components/input.js
+++ b/src/components/input.js
@@ -114,7 +114,9 @@ class ColorPicker extends React.Component {
   }
 
   focus() {
-    this._inputElement.focus()
+    if(this._inputElement) {
+      this._inputElement.focus()
+    }
   }
 
   handlePickerChange = (color) => {


### PR DESCRIPTION
This fixes open issue #3 - what is happening is that sanity defers dom loading and `this._inputElement` is not defined when nested inside an object within sanity. 